### PR TITLE
Bug Fix: Don't call with --local if outside repo

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -49,7 +49,7 @@ function get_current_action () {
 }
 
 function build_prompt {
-    local enabled=`git config --get oh-my-git.enabled`
+    local enbaled=$(if [ -d .git ]; then git config --local --get oh-my-git.enabled; else git config --get oh-my-git.enabled; fi)
     if [[ ${enabled} == false ]]; then
         echo "${PSORG}"
         exit;


### PR DESCRIPTION
Git will complain if you call `git config` with `--local` switch outside a git repo. This check reverts back to default lookup (which will end up being global) if not inside a git repo.